### PR TITLE
Add interview assistant prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+bin/
+obj/
+*.user
+*.db
+*.suo
+*.cache

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # Crackitai-final
+
+This repository holds a prototype for a live interview assistant. The backend is built with ASP.NET Core while the frontend uses plain JavaScript so it can evolve to any framework in the future.
+
+## Setup
+
+1. Install the .NET SDK 8.0 or newer.
+2. `cd backend`
+3. Run the API with `dotnet run`. The API serves the frontend from the `frontend` folder.
+4. Navigate to `http://localhost:5000` in your browser.
+
+The front end captures audio from a shared browser tab, sends it to the backend, and displays the ChatGPT response.
+
+To capture audio from a meeting tab the browser will ask to share your screen or tab when you press **Share Meeting Tab**. After five seconds the audio is sent to the API for transcription and the response from ChatGPT is shown below the button. This is a minimal starting point and can be expanded with WebSockets and a richer UI later.
+

--- a/backend/InterviewAssistantApi.csproj
+++ b/backend/InterviewAssistantApi.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,0 +1,88 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using System.IO;
+using System.Net.Http.Json;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddHttpClient();
+
+var app = builder.Build();
+
+var frontendPath = Path.Combine(builder.Environment.ContentRootPath, "..", "frontend");
+app.UseDefaultFiles(new DefaultFilesOptions
+{
+    FileProvider = new PhysicalFileProvider(frontendPath)
+});
+app.UseStaticFiles(new StaticFileOptions
+{
+    FileProvider = new PhysicalFileProvider(frontendPath)
+});
+
+app.MapPost("/api/transcribe", async (HttpContext http, IHttpClientFactory httpClientFactory) =>
+{
+    if (!http.Request.HasFormContentType)
+    {
+        return Results.BadRequest();
+    }
+
+    var form = await http.Request.ReadFormAsync();
+    if (!form.Files.Any())
+    {
+        return Results.BadRequest();
+    }
+
+    await using var stream = form.Files[0].OpenReadStream();
+
+    var client = httpClientFactory.CreateClient();
+    client.DefaultRequestHeaders.Add("Authorization", $"Bearer YOUR_OPENAI_API_KEY");
+
+    using var content = new MultipartFormDataContent();
+    content.Add(new StreamContent(stream), "file", form.Files[0].FileName);
+    content.Add(new StringContent("whisper-1"), "model");
+
+    var response = await client.PostAsync("https://api.openai.com/v1/audio/transcriptions", content);
+    response.EnsureSuccessStatusCode();
+    var result = await response.Content.ReadFromJsonAsync<TranscribeResponse>();
+
+    return Results.Json(new { text = result?.Text });
+});
+
+app.MapPost("/api/chat", async (HttpContext http, IHttpClientFactory httpClientFactory) =>
+{
+    var request = await http.Request.ReadFromJsonAsync<ChatRequest>();
+    if (request == null || string.IsNullOrWhiteSpace(request.Prompt))
+    {
+        return Results.BadRequest();
+    }
+
+    var client = httpClientFactory.CreateClient();
+    // Replace YOUR_OPENAI_API_KEY with your key or load from configuration
+    client.DefaultRequestHeaders.Add("Authorization", $"Bearer YOUR_OPENAI_API_KEY");
+
+    var openAiRequest = new
+    {
+        model = "gpt-3.5-turbo",
+        messages = new[]
+        {
+            new { role = "user", content = request.Prompt }
+        }
+    };
+
+    var response = await client.PostAsJsonAsync("https://api.openai.com/v1/chat/completions", openAiRequest);
+    response.EnsureSuccessStatusCode();
+    var completion = await response.Content.ReadFromJsonAsync<OpenAiResponse>();
+    var content = completion?.Choices?[0]?.Message?.Content;
+
+    return Results.Json(new { response = content });
+});
+
+app.Run();
+
+record ChatRequest(string Prompt);
+record OpenAiResponse(OpenAiChoice[] Choices);
+record OpenAiChoice(OpenAiMessage Message);
+record OpenAiMessage(string Content);
+record TranscribeResponse(string Text);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Interview Assistant</title>
+</head>
+<body>
+    <h1>Interview Assistant</h1>
+    <button id="share">Share Meeting Tab</button>
+    <pre id="output"></pre>
+    <script src="script.js"></script>
+</body>
+</html>
+

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,0 +1,31 @@
+const shareButton = document.getElementById('share');
+const output = document.getElementById('output');
+
+shareButton.addEventListener('click', async () => {
+    const stream = await navigator.mediaDevices.getDisplayMedia({ audio: true, video: true });
+    const mediaRecorder = new MediaRecorder(stream, { mimeType: 'audio/webm' });
+    const chunks = [];
+
+    mediaRecorder.ondataavailable = e => {
+        if (e.data.size > 0) chunks.push(e.data);
+    };
+
+    mediaRecorder.onstop = async () => {
+        const blob = new Blob(chunks, { type: 'audio/webm' });
+        const form = new FormData();
+        form.append('file', blob, 'audio.webm');
+        const response = await fetch('/api/transcribe', { method: 'POST', body: form });
+        const { text } = await response.json();
+
+        const chatResp = await fetch('/api/chat', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ prompt: text })
+        });
+        const { response: answer } = await chatResp.json();
+        output.textContent += `\nQ: ${text}\nA: ${answer}\n`;
+    };
+
+    mediaRecorder.start();
+    setTimeout(() => mediaRecorder.stop(), 5000); // capture 5 seconds
+});


### PR DESCRIPTION
## Summary
- add initial README content
- ignore build artifacts
- create .NET backend with ChatGPT and transcription endpoints
- add simple JavaScript frontend for capturing meeting audio

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b1a86ddc8324ad282bea1d24cdec